### PR TITLE
Remove file-roller as a requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - lz4
 ### Linux
 ```
-apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract file-roller rename
+apt install unace unrar zip unzip p7zip-full p7zip-rar sharutils rar uudeview mpack arj cabextract rename
 apt install liblzma-dev python-pip brotli lz4
 pip install backports.lzma protobuf pycrypto
 ```


### PR DESCRIPTION
For headless/remote server users, comes with unnecessary xorg dependencies, for those not using headless, they already have an archive tool present