### PR TITLE
extractor: handle sparse ext4 images for AP tars

### DIFF
--- a/extractor.sh
+++ b/extractor.sh
@@ -347,6 +347,9 @@ elif [[ $(7z l -ba "$romzip" | grep tar.md5 | gawk '{ print $NF }' | grep AP_) ]
     if [[ -f super.img ]]; then
         superimage
     fi
+    if [[ -f system.img.ext4 ]]; then
+        find "$tmpdir" -maxdepth 1 -type f -name "*.img.ext4" | rename 's/.img.ext4/.img/g' > /dev/null 2>&1
+    fi
     if [[ ! -f system.img ]]; then
         echo "Extract failed"
         rm -rf "$tmpdir"


### PR DESCRIPTION
In some Samsung firmware packages,
some images including the system image seem to be in the format of sparse ext4 images although,
the script can handle such images it is not done for Samsung firmware packages, therefore,
the script errors out as it can't find a system.img for further continuation of the extraction.

As a solution to this, rename all the sparse ext4 images to image format if system.img.ext4 exists.

Test: Firmware extraction of T860XXU3BTK2 is successful

Signed-off-by: Daniel Jacob Chittoor <djchittoor47@gmail.com>