### PR TITLE
Update extractor.sh

### DIFF
--- a/extractor.sh
+++ b/extractor.sh
@@ -66,8 +66,10 @@ else
 fi
 if [[ ! -d "$toolsdir/oppo_ozip_decrypt" ]]; then
     git clone -q https://github.com/bkerler/oppo_ozip_decrypt.git "$toolsdir/oppo_ozip_decrypt"
+    git -C "$toolsdir/oppo_ozip_decrypt" reset -q --hard d02128dade8fffaf16e00f9f7d01f7be39558f69
 else
     git -C "$toolsdir/oppo_ozip_decrypt" pull
+    git -C "$toolsdir/oppo_ozip_decrypt" reset -q --hard d02128dade8fffaf16e00f9f7d01f7be39558f69
 fi
 if [[ ! -d "$toolsdir/update_payload_extractor" ]]; then
     git clone -q https://github.com/erfanoabdi/update_payload_extractor.git "$toolsdir/update_payload_extractor"


### PR DESCRIPTION
- This patch temporarily fixes the extraction failure of non-encrypted ozip files
  More detail on https://github.com/bkerler/oppo_ozip_decrypt/issues/64

Signed-off-by: rokibhasansagar <rokibhasansagar2014@outlook.com>