### PR TITLE
extractor.sh: otadump: list payload.bin content

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ If you get syntax errors run dos2unix on extractor.sh
 ### Misc
 
 - Install rust using https://rustup.rs/
-- Run `cargo install otadump`
+- Run `git clone https://github.com/crazystylus/otadump` , `cd otadump/`, `cargo build --release`.
+- Navigate to `/target/release` and add the generated `otadump` executable to your PATH.
 
 ## How to use
 ### Download

--- a/extractor.sh
+++ b/extractor.sh
@@ -423,7 +423,7 @@ elif [[ $(7z l -ba "$romzip" | grep .tar) && ! $(7z l -ba "$romzip" | grep tar.m
 elif [[ $(7z l -ba "$romzip" | grep payload.bin) ]]; then
     echo "AB OTA detected"
     7z e -y "$romzip" payload.bin 2>/dev/null >> $tmpdir/zip.log
-    otadump -o $tmpdir payload.bin || $payload_go -o $tmpdir $romzip
+    otadump --list payload.bin && otadump -o $tmpdir payload.bin || $payload_go -o $tmpdir $romzip
     for partition in $PARTITIONS; do
         [[ -e "$tmpdir/$partition.img" ]] && mv "$tmpdir/$partition.img" "$outdir/$partition.img"
     done

--- a/extractor.sh
+++ b/extractor.sh
@@ -423,7 +423,10 @@ elif [[ $(7z l -ba "$romzip" | grep .tar) && ! $(7z l -ba "$romzip" | grep tar.m
 elif [[ $(7z l -ba "$romzip" | grep payload.bin) ]]; then
     echo "AB OTA detected"
     7z e -y "$romzip" payload.bin 2>/dev/null >> $tmpdir/zip.log
-    otadump --list payload.bin && otadump -o $tmpdir payload.bin || $payload_go -o $tmpdir $romzip
+    [[ "$(command -v otadump)" ]] && {
+        otadump --list payload.bin
+        otadump -o $tmpdir payload.bin
+    } || $payload_go -o $tmpdir $romzip
     for partition in $PARTITIONS; do
         [[ -e "$tmpdir/$partition.img" ]] && mv "$tmpdir/$partition.img" "$outdir/$partition.img"
     done


### PR DESCRIPTION
This is already done by `payload-dumper-go` , hence doing it with `otadump` too. Requires compiling from source though, as https://github.com/crazystylus/otadump/commit/740f516762abad6f107c76678408322ef1114237 isn't part of `otadump` [0.1.2](https://github.com/crazystylus/otadump/compare/0.1.2...mainline) .

Test: `./extractor.sh input/sailfish-ota-nde63h-995d0511.zip` with `otadump` in PATH and not in PATH

For reference, below is an extract of the output with `otadump` in PATH
```sh
onenormalusername@DESKTOP-FUCTTJ4:~/Firmware_Extractor$ ./extractor.sh input/sailfish-ota-nde63h-995d0511.zip
Create Temp and out dir
Extracting firmware on: /home/onenormalusername/Firmware_Extractor/out
AB OTA detected
aboot (2.53 MiB)
apdp (16.00 KiB)
boot (24.48 MiB)
bootlocker (76.00 KiB)
cmnlib32 (204.00 KiB)
cmnlib64 (256.00 KiB)
devcfg (52.00 KiB)
hosd (23.81 MiB)
hyp (256.00 KiB)
keymaster (352.00 KiB)
modem (55.70 MiB)
pmic (44.00 KiB)
rpm (228.00 KiB)
system (2.00 GiB)
tz (1.58 MiB)
vendor (300.00 MiB)
xbl (1.75 MiB)
```

Below is an extract of the output with `otadump` not in PATH
```sh
onenormalusername@DESKTOP-FUCTTJ4:~/Firmware_Extractor$ ./extractor.sh input/sailfish-ota-nde63h-995d0511.zip
Already up to date.
Already up to date.
Create Temp and out dir
Extracting firmware on: /home/onenormalusername/Firmware_Extractor/out
AB OTA detected
./extractor.sh: line 426: otadump: command not found
Please wait while extracting payload.bin from the archive.
payload.bin: /tmp/payload_179426888.bin
Payload Version: 2
Payload Manifest Length: 70491
Payload Manifest Signature Length: 264
Found partitions:
aboot (2.7 MB), keymaster (360 kB), pmic (45 kB), cmnlib32 (209 kB), xbl (1.8 MB), hosd (25 MB), apdp (16 kB), boot (26 MB), system (2.1 GB), cmnlib64 (262 kB), rpm (234 kB), hyp (262 kB), tz (1.7 MB), vendor (315 MB), devcfg (53 kB), bootlocker (78 kB), modem (58 MB)
```